### PR TITLE
A few small fixes/generalizations for the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something is occurring that I think is wrong
+title: ''
+labels: "\U0001F41B bug"
+assignees: ''
+
+---
+
+## What is the current behavior?
+
+> What's happening that seems wrong?
+
+## Steps to reproduce
+
+> To make it faster to diagnose the root problem. Tell us how can we reproduce the bug.
+
+## Expected behavior
+
+> What would you expect to happen when following the steps above?
+
+## Please tell us about your environment
+
+> We want to make sure the problem isn't specific to your operating system or programming language.
+  
+- **Operating System/Version:** Windows 10
+- **Language:** [all | TypeScript | Python | PHP | etc]
+- **Browser:** Chrome
+
+## Other information
+
+> Anything else we should know? (e.g. detailed explanation, stack-traces, related issues, suggestions how to fix, links for us to have context, e.g. stack overflow, codepen, etc)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: false
+contact_links:
+  - name: DeepgramDevs on Twitter
+    url: https://twitter.com/DeepgramDevs

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: I think X would be a cool addition or change.
+title: ''
+labels: "✨ enhancement"
+assignees: ''
+
+---
+
+## Proposed changes
+
+> Provide a detailed description of the change or addition you are proposing
+
+## Context
+
+> Why is this change important to you? How would you use it? How can it benefit other users?
+
+## Possible Implementation
+
+> Not obligatory, but suggest an idea for implementing addition or change
+
+## Other information
+
+> Anything else we should know? (e.g. detailed explanation, related issues, links for us to have context, e.g. stack overflow, codepen, etc)

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,27 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update or tests (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) doc
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,28 +6,23 @@ Here are a few types of contributions that we would be interested in hearing abo
 
 * Bug fixes
   * If you find a bug, please first report it using Github Issues.
-  * Issues that have already been identified as a bug will be labeled `bug`.
+  * Issues that have already been identified as a bug will be labeled `🐛 bug`.
     * If you'd like to submit a fix for a bug, send a Pull Request from your own fork and mention the Issue number.
       * Include a test that isolates the bug and verifies that it was fixed.
 * New Features
   * If you'd like to accomplish something in the extension that it doesn't already do, describe the problem in a new Github Issue.
-    * Issues that have been identified as a feature request will be labeled `enhancement`.
+    * Issues that have been identified as a feature request will be labeled `✨ enhancement`.
     * If you'd like to implement the new feature, please wait for feedback from the project maintainers before spending
-      too much time writing the code. In some cases, `enhancement`s may not align well with the project objectives at
+      too much time writing the code. In some cases, `✨ enhancement`s may not align well with the project objectives at
       the time.
 * Tests, Documentation, Miscellaneous
   * If you think the test coverage could be improved, the documentation could be clearer, you've got an alternative
     implementation of something that may have more advantages, or any other change we would still be glad hear about
     it.
-    * If its a trivial change, go ahead and send a Pull Request with the changes you have in mind
+    * If it's a trivial change, go ahead and send a Pull Request with the changes you have in mind
     * If not, open a Github Issue to discuss the idea first.
-* Snippets
-  * To add snippets:
-    * Add a directory in the `snippets` folder with the name of the language.
-    * Add one or more files in the language directory with snippets.
-    * Update the `package.json` to include the snippets you added.
 
-We also welcome anyone to work on any existing issues with the `good first issue` tag.
+We also welcome anyone to work on any existing issues with the `👋🏽 good first issue` tag.
 
 ## Requirements
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Deepgram Devs
+Copyright (c) 2022 Deepgram Devs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To make sure our community is safe for all, be sure to review and agree to our
 We love to hear from you so if you have questions, comments or find a bug in the
 project, let us know! You can either:
 
-- [Open an issue](https://github.com/deepgram/[reponame]/issues/new) on this repository
+- [Open an issue](https://github.com/deepgram-devs/[reponame]/issues/new) on this repository
 - Tweet at us! We're [@DeepgramDevs on Twitter](https://twitter.com/DeepgramDevs)
 
 ## Further Reading


### PR DESCRIPTION
Most of these were originally brought up in https://github.com/deepgram-devs/deepgram-rust-sdk/pull/2.

Also includes some files copied over from [deepgram/oss-repo-template](https://github.com/deepgram/oss-repo-template).